### PR TITLE
Update cpmp_wp_admin_nav_menus.js

### DIFF
--- a/cpmp_wp_admin_nav_menus.js
+++ b/cpmp_wp_admin_nav_menus.js
@@ -2,20 +2,31 @@
 
 	$(document).ready(function(){
 
-		$('.cpmp-description > p.description:not(:first-child)').addClass('hidden');
-
 		var toggle = function(){
 			var checked = $(this).is(':checked');
+			var container = $(this).parent().parent();
 			var items = $(this).parents('.cpmp-description').find('p.description:not(:first-child)');
 
 			if(checked) {
+				container.css('margin-bottom', '');
 				items.removeClass('hidden');
 			} else {
+				container.css('margin-bottom', 0);
 				items.addClass('hidden');
 			}
 		};
 
-		$('.cpmp-description > .field-cpcm-unfold input[type="checkbox"]').on('change', toggle).trigger('change');
+		var init = function(){
+			$('.cpmp-description > p.description:not(:first-child)').addClass('hidden');
+			$('.cpmp-description > .field-cpcm-unfold input[type="checkbox"]').off('change', toggle).on('change', toggle).trigger('change');
+		};
+
+		$(document).on('menu-item-added', function(){
+			init();
+		});
+
+		init();
+		wpNavMenu.menusChanged = false;
 
 	});
 


### PR DESCRIPTION
Remove bottom margin from unchecked main checkbox container to improve spacing.
When adding a new menu item with AJAX hide it's CPCM fields.
Set wpNavMenu.menusChanged to false after setting up checkboxes onload.